### PR TITLE
Strain Gauge Converter Library

### DIFF
--- a/crates/straingauge_converter/Cargo.toml
+++ b/crates/straingauge_converter/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 name = "straingauge-converter"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2025"

--- a/crates/straingauge_converter/Cargo.toml
+++ b/crates/straingauge_converter/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "straingauge-converter"
+version = "0.1.0"
+edition = "2025"

--- a/crates/straingauge_converter/src/lib.rs
+++ b/crates/straingauge_converter/src/lib.rs
@@ -8,15 +8,49 @@ const GAUGE_FACTOR: f64 = 2.0; // Gauge factor for the strain gauge
 const V_REF: f64 = 5.0; // Output voltage reference
 
 /*
-* Function to convert voltage to strain
+* Function to convert voltage to strain in quarter bridge configuration
+*
+* @param voltage: f64 - The voltage output from the strain gauge
+* @param gauge_factor: f64 - The gauge factor of the strain gauge default is 2.0
+* @return strain: f64 - The calculated strain value
+ */
+pub fn voltage_to_strain_quart(voltage: f64, gauge_factor: f64) -> f64 {
+    // Convert voltage to strain using the gauge factor and resistance
+    let mut strain = (voltage) / ((0.25) * GAUGE_FACTOR * V_REF);
+    // Apply correction factor
+    if gauge_factor != 0.0 || !gauge_factor.is_nan() {
+        strain = strain * (GAUGE_FACTOR / gauge_factor);
+    }
+    return strain;
+}
+
+/*
+* Function to convert voltage to strain in half bridge configuration
+*
+* @param voltage: f64 - The voltage output from the strain gauge
+* @param gauge_factor: f64 - The gauge factor of the strain gauge default is 2.0
+* @return strain: f64 - The calculated strain value
+ */
+pub fn voltage_to_strain_half(voltage: f64, gauge_factor: f64) -> f64 {
+    // Convert voltage to strain using the gauge factor and resistance
+    let mut strain = (voltage) / ((0.5) * GAUGE_FACTOR * V_REF);
+    // Apply correction factor
+    if gauge_factor != 0.0 || !gauge_factor.is_nan() {
+        strain = strain * (GAUGE_FACTOR / gauge_factor);
+    }
+    return strain;
+}
+
+/*
+* Function to convert voltage to strain in full bridge configuration
 *
 * @param voltage: f64 - The voltage output from the strain gauge
 * @param gauge_factor: f64 - The gauge factor of the strain gauge
 * @return strain: f64 - The calculated strain value
  */
-pub fn voltage_to_strain(voltage: f64, gauge_factor: f64) -> f64 {
+pub fn voltage_to_strain_full(voltage: f64, gauge_factor: f64) -> f64 {
     // Convert voltage to strain using the gauge factor and resistance
-    let mut strain = (voltage) / ((0.25) * GAUGE_FACTOR * V_REF);
+    let mut strain = (voltage) / (GAUGE_FACTOR * V_REF);
     // Apply correction factor
     if gauge_factor != 0.0 || !gauge_factor.is_nan() {
         strain = strain * (GAUGE_FACTOR / gauge_factor);

--- a/crates/straingauge_converter/src/lib.rs
+++ b/crates/straingauge_converter/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 
 /// Coefficients for strain gauge conversion
-const GAUGE_FACTOR: f64 = 2.0; // Gauge factor for the strain gauge
+const GAUGE_FACTOR: f64 = 2.0; 
 const V_REF: f64 = 5.0; // Output voltage reference
 
 /*
@@ -15,7 +15,6 @@ const V_REF: f64 = 5.0; // Output voltage reference
 * @return strain: f64 - The calculated strain value
  */
 pub fn voltage_to_strain_quart(voltage: f64, gauge_factor: f64) -> f64 {
-    // Convert voltage to strain using the gauge factor and resistance
     let mut strain = (voltage) / ((0.25) * GAUGE_FACTOR * V_REF);
     // Apply correction factor
     if gauge_factor != 0.0 || !gauge_factor.is_nan() {
@@ -32,7 +31,6 @@ pub fn voltage_to_strain_quart(voltage: f64, gauge_factor: f64) -> f64 {
 * @return strain: f64 - The calculated strain value
  */
 pub fn voltage_to_strain_half(voltage: f64, gauge_factor: f64) -> f64 {
-    // Convert voltage to strain using the gauge factor and resistance
     let mut strain = (voltage) / ((0.5) * GAUGE_FACTOR * V_REF);
     // Apply correction factor
     if gauge_factor != 0.0 || !gauge_factor.is_nan() {
@@ -49,7 +47,6 @@ pub fn voltage_to_strain_half(voltage: f64, gauge_factor: f64) -> f64 {
 * @return strain: f64 - The calculated strain value
  */
 pub fn voltage_to_strain_full(voltage: f64, gauge_factor: f64) -> f64 {
-    // Convert voltage to strain using the gauge factor and resistance
     let mut strain = (voltage) / (GAUGE_FACTOR * V_REF);
     // Apply correction factor
     if gauge_factor != 0.0 || !gauge_factor.is_nan() {

--- a/crates/straingauge_converter/src/lib.rs
+++ b/crates/straingauge_converter/src/lib.rs
@@ -5,7 +5,6 @@
 
 /// Coefficients for strain gauge conversion
 const GAUGE_FACTOR: f64 = 2.0; // Gauge factor for the strain gauge
-const RESISTANCE: f64 = 120.0; // Resistance of the strain gauge in ohms
 const V_REF: f64 = 5.0; // Output voltage reference
 
 /*
@@ -19,6 +18,8 @@ pub fn voltage_to_strain(voltage: f64, gauge_factor: f64) -> f64 {
     // Convert voltage to strain using the gauge factor and resistance
     let mut strain = (voltage) / ((0.25) * GAUGE_FACTOR * V_REF);
     // Apply correction factor
-    strain = strain * (GAUGE_FACTOR / gauge_factor);
+    if gauge_factor != 0.0 || !gauge_factor.is_nan() {
+        strain = strain * (GAUGE_FACTOR / gauge_factor);
+    }
     return strain;
 }

--- a/crates/straingauge_converter/src/lib.rs
+++ b/crates/straingauge_converter/src/lib.rs
@@ -1,0 +1,24 @@
+#![no_std]
+//!
+//! This crate contains code to convert strain gauge voltages to temperatures.
+//!
+
+/// Coefficients for strain gauge conversion
+const GAUGE_FACTOR: f64 = 2.0; // Gauge factor for the strain gauge
+const RESISTANCE: f64 = 120.0; // Resistance of the strain gauge in ohms
+const V_REF: f64 = 5.0; // Output voltage reference
+
+/*
+* Function to convert voltage to strain
+*
+* @param voltage: f64 - The voltage output from the strain gauge
+* @param gauge_factor: f64 - The gauge factor of the strain gauge
+* @return strain: f64 - The calculated strain value
+ */
+pub fn voltage_to_strain(voltage: f64, gauge_factor: f64) -> f64 {
+    // Convert voltage to strain using the gauge factor and resistance
+    let mut strain = (voltage) / ((0.25) * GAUGE_FACTOR * V_REF);
+    // Apply correction factor
+    strain = strain * (GAUGE_FACTOR / gauge_factor);
+    return strain;
+}

--- a/crates/straingauge_converter/src/lib.rs
+++ b/crates/straingauge_converter/src/lib.rs
@@ -40,7 +40,7 @@ pub fn voltage_to_strain_half(voltage: f64, gauge_factor: f64) -> f64 {
 }
 
 /*
-* Function to convert voltage to strain in full bridge configuration
+* Function to convert voltage to strain in full bridge configuration.
 *
 * @param voltage: f64 - The voltage output from the strain gauge
 * @param gauge_factor: f64 - The gauge factor of the strain gauge


### PR DESCRIPTION
--linear strain gauge converter library
--implements quarter, half and full bridge configs
--default gauge factor of 2.0
--optional gauge factor to offset error

closes straingauge_lib