### PR TITLE
feat: migrate phoenix sound & music to monorepo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ dependencies = [
  "defmt 0.3.100",
  "defmt-rtt",
  "embassy-embedded-hal 0.3.2",
- "embassy-executor",
+ "embassy-executor 0.7.0",
  "embassy-futures",
  "embassy-net",
  "embassy-stm32",
@@ -472,7 +472,21 @@ dependencies = [
  "critical-section",
  "defmt 0.3.100",
  "document-features",
- "embassy-executor-macros",
+ "embassy-executor-macros 0.6.2",
+]
+
+[[package]]
+name = "embassy-executor"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06070468370195e0e86f241c8e5004356d696590a678d47d6676795b2e439c6b"
+dependencies = [
+ "cortex-m",
+ "critical-section",
+ "defmt 1.0.1",
+ "document-features",
+ "embassy-executor-macros 0.7.0",
+ "embassy-executor-timer-queue",
 ]
 
 [[package]]
@@ -486,6 +500,24 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "embassy-executor-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfdddc3a04226828316bf31393b6903ee162238576b1584ee2669af215d55472"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "embassy-executor-timer-queue"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc328bf943af66b80b98755db9106bf7e7471b0cf47dc8559cd9a6be504cc9c"
 
 [[package]]
 name = "embassy-futures"
@@ -679,7 +711,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc55c748d16908a65b166d09ce976575fb8852cf60ccd06174092b41064d8f83"
 dependencies = [
- "embassy-executor",
+ "embassy-executor 0.7.0",
  "heapless 0.8.0",
 ]
 
@@ -880,7 +912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebf10fe8d8fcdca0d69d961e2ffdc51b5101811649342078d4efa8ca2370fe17"
 dependencies = [
  "defmt 1.0.1",
- "embassy-executor",
+ "embassy-executor 0.7.0",
  "embedded-test-macros",
  "heapless 0.8.0",
  "semihosting",
@@ -1420,6 +1452,23 @@ checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "phoenix"
+version = "0.1.0"
+dependencies = [
+ "cortex-m",
+ "cortex-m-rt",
+ "defmt 0.3.100",
+ "defmt-rtt",
+ "embassy-executor 0.9.1",
+ "embassy-stm32",
+ "embassy-sync 0.6.2",
+ "embassy-time 0.5.0",
+ "embedded-alloc",
+ "panic-probe",
+ "static_cell",
 ]
 
 [[package]]

--- a/boards/phoenix/.cargo/config.toml
+++ b/boards/phoenix/.cargo/config.toml
@@ -1,0 +1,9 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+runner = "probe-rs run --chip STM32H733VGTx --protocol swd"
+rustflags = ["-C", "link-arg=-Tlink.x", "-C", "link-arg=-Tdefmt.x"]
+
+[env]
+DEFMT_LOG = "debug,embedded_sdmmc=info"
+
+[build]
+target = "thumbv7em-none-eabihf"

--- a/boards/phoenix/Cargo.toml
+++ b/boards/phoenix/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "phoenix"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+harness = false
+
+[features]
+default = ["music"]
+music = []
+
+[dependencies]
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+static_cell = "2"
+embassy-sync = { version = "0.6.2", features = ["defmt"] }
+embassy-executor = { version = "0.9.1", features = [
+	"nightly",
+	"arch-cortex-m",
+	"executor-thread",
+	"executor-interrupt",
+	"defmt",
+] }
+embedded-alloc = { workspace = true }
+defmt = { workspace = true }
+defmt-rtt = { workspace = true }
+embassy-stm32 = { version = "0.2.0", features = [
+	"defmt",
+	"time-driver-tim2",
+	"stm32h733vg",
+	"memory-x",
+	"unstable-pac",
+] }
+embassy-time = { version = "0.5.0", features = [
+	"defmt",
+	"defmt-timestamp-uptime",
+	"tick-hz-32_768",
+] }
+panic-probe.workspace = true

--- a/boards/phoenix/build.rs
+++ b/boards/phoenix/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+	// Needed by embedded_test crate to function
+	println!("cargo::rustc-link-arg=-Tembedded-test.x");
+}

--- a/boards/phoenix/rust-toolchain.toml
+++ b/boards/phoenix/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+targets = ["thumbv7em-none-eabihf"]

--- a/boards/phoenix/src/lib.rs
+++ b/boards/phoenix/src/lib.rs
@@ -1,0 +1,7 @@
+#![no_std]
+#![no_main]
+
+#[cfg(feature = "music")]
+pub mod music;
+pub mod sound;
+pub mod utils;

--- a/boards/phoenix/src/main.rs
+++ b/boards/phoenix/src/main.rs
@@ -1,0 +1,35 @@
+#![no_std]
+#![no_main]
+#![feature(impl_trait_in_assoc_type)]
+
+use defmt::info;
+use embassy_executor::Spawner;
+use embassy_stm32::peripherals::TIM3;
+use panic_probe as _;
+use phoenix::{
+	sound::service::SoundService,
+	utils::{
+		hal::{HEAP, configure_hal},
+		types::AsyncMutex,
+	},
+};
+use static_cell::StaticCell;
+
+static SOUND_SERVICE: StaticCell<AsyncMutex<SoundService<TIM3>>> = StaticCell::new();
+#[cfg(feature = "music")]
+static MUSIC_SERVICE: StaticCell<AsyncMutex<phoenix::music::service::MusicService<TIM3>>> = StaticCell::new();
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+	info!("Starting up...");
+	let p = configure_hal();
+	info!("Heap usage: {} bytes", HEAP.used());
+
+	let sound = SOUND_SERVICE.init(AsyncMutex::new(SoundService::new(p.TIM3, p.PC6)));
+
+	#[cfg(feature = "music")]
+	{
+		use phoenix::music::service::MusicService;
+		let music = MUSIC_SERVICE.init(AsyncMutex::new(MusicService::new(sound)));
+	}
+}

--- a/boards/phoenix/src/music/mod.rs
+++ b/boards/phoenix/src/music/mod.rs
@@ -1,0 +1,9 @@
+//! Music playback for Phoenix.
+//!
+//! This module provides functionality for playing music and sound effects using a PWM buzzer.
+//! Some provided songs are included in [songs], along with a simple DSL macro for defining new songs.
+
+pub mod service;
+pub mod songs;
+pub mod tasks;
+pub mod types;

--- a/boards/phoenix/src/music/service.rs
+++ b/boards/phoenix/src/music/service.rs
@@ -1,0 +1,36 @@
+//! Playback of some simple songs with the buzzer
+use embassy_stm32::timer::GeneralInstance4Channel;
+use embassy_time::Timer;
+
+use crate::{
+	music::types::{Melody, Note},
+	sound::service::SoundService,
+	utils::types::AsyncMutex,
+};
+
+pub struct MusicService<T: GeneralInstance4Channel> {
+	sound_service: &'static AsyncMutex<SoundService<T>>,
+}
+
+impl<T: GeneralInstance4Channel> MusicService<T> {
+	pub fn new(sound_service: &'static AsyncMutex<SoundService<T>>) -> Self {
+		Self { sound_service }
+	}
+
+	pub async fn play_song(
+		&self,
+		song: Melody,
+		tempo: f32,
+	) {
+		let beat_length = 60_000f32 / tempo;
+		let mut sound = self.sound_service.lock().await;
+
+		for (note, length) in song {
+			let duration = (length * beat_length) as u64;
+			match note {
+				Note::Pitch(freq) => sound.play_pitch(*freq, duration).await,
+				Note::Rest => Timer::after_millis(duration).await,
+			}
+		}
+	}
+}

--- a/boards/phoenix/src/music/songs.rs
+++ b/boards/phoenix/src/music/songs.rs
@@ -1,0 +1,48 @@
+//! A bunch of songs to play with the buzzer.
+
+// TODO: Implement a DSL macro to easily add songs to the module.
+// macro_rules! add_song {
+//     (eval ) => {
+//
+//     };
+// }
+
+// NOTE: Here are some of the previous songs, written in an alternate format.
+
+use crate::music::types::Melody;
+
+pub const PLAYLIST: [Melody; 0] = [];
+
+// pub const MARIO_MELODY: Melody = &[
+// 	(E5, 1.0),
+// 	(E5, 1.0),
+// 	(Rest, 1.0),
+// 	(E5, 1.0),
+// 	(Rest, 1.0),
+// 	(C5, 1.0),
+// 	(E5, 1.0),
+// 	(Rest, 1.0),
+// 	(G5, 2.0),
+// 	(Rest, 2.0),
+// 	(G4, 2.0),
+// 	(Rest, 2.0),
+// ];
+//
+// /// Melody for "Twinkle, Twinkle, Little Star"
+// pub const TWINKLE_MELODY: Melody = &[
+// 	(C4, 1.0),
+// 	(C4, 1.0),
+// 	(G4, 1.0),
+// 	(G4, 1.0),
+// 	(A4, 1.0),
+// 	(A4, 1.0),
+// 	(G4, 2.0),
+// 	(Rest, 0.5),
+// 	(F4, 1.0),
+// 	(F4, 1.0),
+// 	(E4, 1.0),
+// 	(E4, 1.0),
+// 	(D4, 1.0),
+// 	(D4, 1.0),
+// 	(C4, 2.0),
+// ];

--- a/boards/phoenix/src/music/tasks.rs
+++ b/boards/phoenix/src/music/tasks.rs
@@ -1,0 +1,17 @@
+use embassy_stm32::timer::GeneralInstance4Channel;
+
+use crate::{
+	music::{service::MusicService, songs::PLAYLIST},
+	utils::types::AsyncMutex,
+};
+
+// FIXME: Embassy tasks don't allow generics, but we kinda need some if we don't want to be forced
+// into hardcoding a specific pin in the library code.
+//
+// Potential fix could involve creating a macro which generates the task and using the macro at the
+// top level of `main.rs`
+
+// #[embassy_executor::task]
+// async fn play_music_forever(music: &'static AsyncMutex<MusicService<impl GeneralInstance4Channel>>) {
+// 	for song in PLAYLIST {}
+// }

--- a/boards/phoenix/src/music/types.rs
+++ b/boards/phoenix/src/music/types.rs
@@ -1,0 +1,10 @@
+/// A note, representing either a pitch (with a frequency in Hz), or a rest.
+// NOTE: Derive Copy since it's basically just a cheap u32 copy
+#[derive(Clone, Copy)]
+pub enum Note {
+	Pitch(u32),
+	Rest,
+}
+
+/// An array of notes with a length, in beats.
+pub type Melody = &'static [(Note, f32)];

--- a/boards/phoenix/src/sound/mod.rs
+++ b/boards/phoenix/src/sound/mod.rs
@@ -1,0 +1,5 @@
+//! Simple sound output via the onboard buzzer.
+//!
+//! For more complex sound output, see [crate::music].
+
+pub mod service;

--- a/boards/phoenix/src/sound/service.rs
+++ b/boards/phoenix/src/sound/service.rs
@@ -1,0 +1,61 @@
+use embassy_stm32::{
+	Peripheral,
+	gpio::OutputType,
+	time::{Hertz, khz},
+	timer::{
+		Channel1Pin, GeneralInstance4Channel,
+		simple_pwm::{PwmPin, SimplePwm},
+	},
+};
+use embassy_time::Timer;
+
+/// Play sounds using a PWM buzzer.
+///
+/// This struct requires generics over the timer peripheral used for PWM generation, due to a lack of an `AnyPin` in embassy.
+/// This can cause some issues when depending on this service in contexts where generics are not possible (e.g. in an embassy task).
+pub struct SoundService<T: GeneralInstance4Channel> {
+	pwm: SimplePwm<'static, T>,
+}
+
+impl<T: GeneralInstance4Channel> SoundService<T> {
+	pub fn new(
+		timer: impl Peripheral<P = T> + 'static,
+		buzzer: impl Peripheral<P = impl Channel1Pin<T>> + 'static,
+	) -> Self {
+		let buzz_out_pin = PwmPin::new_ch1(buzzer, OutputType::PushPull);
+		let pwm = SimplePwm::new(timer, Some(buzz_out_pin), None, None, None, khz(4), Default::default());
+		let mut snd = Self { pwm };
+		// Set the volume to 100% by default
+		snd.set_volume(100);
+
+		snd
+	}
+
+	/// Play some pitch with a frequency of `freq` Hz, for `duration` ms.
+	pub async fn play_pitch(
+		&mut self,
+		freq: u32,
+		duration: u64,
+	) {
+		self.pwm.set_frequency(Hertz::hz(freq));
+		self.pwm.ch1().enable();
+		Timer::after_millis(duration).await;
+		self.pwm.ch1().disable();
+	}
+
+	/// Set the duty cycle of the buzzer to change output volume.
+	///
+	/// 100% volume is equal to 50% duty cycle, 0% is 0% duty cycle.
+	/// The caller is responsible for ensuring that `volume_percent <= 200` (the max
+	/// duty cycle).
+	pub fn set_volume(
+		&mut self,
+		volume_percent: u8,
+	) {
+		// NOTE: I'm not sure on how expensive modulo is on this
+		// hardware, so I'll just leave it as is without any protections for
+		// going over 100% duty cycle.
+		let duty_cycle = volume_percent / 2;
+		self.pwm.ch1().set_duty_cycle_percent(duty_cycle);
+	}
+}

--- a/boards/phoenix/src/utils/hal.rs
+++ b/boards/phoenix/src/utils/hal.rs
@@ -1,0 +1,63 @@
+//! Setup and configuration of the HAL.
+use core::mem::MaybeUninit;
+
+use embassy_stm32::{
+	Config, Peripherals, init,
+	rcc::{AHBPrescaler, APBPrescaler, HSIPrescaler, Pll, PllDiv, PllMul, PllPreDiv, PllSource, Sysclk, VoltageScale},
+};
+use embedded_alloc::LlffHeap as Heap;
+
+const HEAP_SIZE: usize = 40_000;
+
+#[global_allocator]
+pub static HEAP: Heap = Heap::empty();
+
+pub fn configure_hal() -> Peripherals {
+	static mut HEAP_MEMORY: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
+
+	#[allow(static_mut_refs)]
+	unsafe {
+		HEAP.init(HEAP_MEMORY.as_ptr() as usize, HEAP_SIZE)
+	}
+
+	let mut config = Config::default();
+
+	// Clock configuration
+	//
+	config.rcc.hsi = Some(HSIPrescaler::DIV1);
+	config.rcc.csi = true;
+
+	config.rcc.pll1 = Some(Pll {
+		source: PllSource::HSI,
+		prediv: PllPreDiv::DIV4,
+		mul: PllMul::MUL50,
+		divp: Some(PllDiv::DIV2),
+		divq: Some(PllDiv::DIV8),
+		divr: None,
+	});
+	config.rcc.pll2 = Some(Pll {
+		source: PllSource::HSI,
+		prediv: PllPreDiv::DIV4,
+		mul: PllMul::MUL50,
+		divp: Some(PllDiv::DIV2),
+		divq: Some(PllDiv::DIV8),
+		divr: None,
+	});
+	config.rcc.pll3 = Some(Pll {
+		source: PllSource::HSI,
+		prediv: PllPreDiv::DIV4,
+		mul: PllMul::MUL50,
+		divp: Some(PllDiv::DIV2),
+		divq: Some(PllDiv::DIV8),
+		divr: None,
+	});
+	config.rcc.sys = Sysclk::PLL1_P; // 400 Mhz
+	config.rcc.ahb_pre = AHBPrescaler::DIV2; // 200 Mhz
+	config.rcc.apb1_pre = APBPrescaler::DIV2; // 100 Mhz
+	config.rcc.apb2_pre = APBPrescaler::DIV2; // 100 Mhz
+	config.rcc.apb3_pre = APBPrescaler::DIV2; // 100 Mhz
+	config.rcc.apb4_pre = APBPrescaler::DIV2; // 100 Mhz
+	config.rcc.voltage_scale = VoltageScale::Scale1;
+
+	init(config)
+}

--- a/boards/phoenix/src/utils/mod.rs
+++ b/boards/phoenix/src/utils/mod.rs
@@ -1,0 +1,2 @@
+pub mod hal;
+pub mod types;

--- a/boards/phoenix/src/utils/types.rs
+++ b/boards/phoenix/src/utils/types.rs
@@ -1,0 +1,4 @@
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
+
+/// Shorthand for an async mutex safe to share between executors and interrupts.
+pub type AsyncMutex<T> = Mutex<CriticalSectionRawMutex, T>;


### PR DESCRIPTION
Migrated the HAL configuration & setup along with music & sound from the original [phoenix code repo](https://github.com/uorocketry/phoenix). Rewrote some parts to conform with the service-style architecture for uniformity with the rest of the avionics monorepo.

Some pretty spotty documentation is included, probably needs some touch-ups before merging.